### PR TITLE
Adding tabnine.

### DIFF
--- a/dot.vimrc
+++ b/dot.vimrc
@@ -11,6 +11,7 @@ Plug 'prabirshrestha/asyncomplete.vim'
 Plug 'prabirshrestha/asyncomplete-lsp.vim'
 Plug 'junegunn/fzf', { 'do': { -> fzf#install() } }
 Plug 'junegunn/fzf.vim'
+Plug 'codota/tabnine-vim'
 call plug#end()
 
 inoremap <expr> <Tab>   pumvisible() ? "\<C-n>" : "\<Tab>"


### PR DESCRIPTION
Requires python support to be installed. In Debian/Ubuntu this is included in the vim-gtk or vim-gtk3 package.